### PR TITLE
Support Shift-JIS

### DIFF
--- a/src/intern/drw_textcodec.h
+++ b/src/intern/drw_textcodec.h
@@ -88,4 +88,18 @@ private:
 
 };
 
+class DRW_ExtConverter : public DRW_Converter {
+public:
+    DRW_ExtConverter(const char *enc):DRW_Converter(NULL, 0) {
+        encoding = enc;
+    }
+    virtual std::string fromUtf8(std::string *s);
+    virtual std::string toUtf8(std::string *s);
+ private:
+    const char *encoding;
+    std::string convertByiconv(const char *in_encode,
+                               const char *out_encode,
+                               const std::string *s);
+};
+
 #endif // DRW_TEXTCODEC_H


### PR DESCRIPTION
This PR enables `dwg2text` to extract Japanese texts from dwg/dxf files before AC1018.